### PR TITLE
Get recordings by user ID

### DIFF
--- a/server/api/recording/recording.routes.http
+++ b/server/api/recording/recording.routes.http
@@ -1,0 +1,23 @@
+###
+# Get recording id = 1
+GET http://localhost:3000/recording/1
+
+###
+# Get all recordings for userId = 1
+GET http://localhost:3000/recording/?user=1
+
+###
+# Delete recording ID (need to specify)
+DELETE http://localhost:3000/recording/23
+
+###
+# Update recording ID
+PUT http://localhost:3000/recording/24
+
+Content-Type: application/json
+{
+  "id": 24,
+  "userId": 1,
+  "questionId": 1,
+  "objectKey": "11709612733971.jpg"
+}

--- a/server/api/recording/recording.routes.ts
+++ b/server/api/recording/recording.routes.ts
@@ -1,17 +1,24 @@
 import express from 'express';
-import { createRecording, getRecordingById, updateRecordingById, deleteRecordingById } from './recording.service';
+import {
+  createRecording,
+  getRecordingById,
+  updateRecordingById,
+  deleteRecordingById,
+  getRecordingByUserId
+} from './recording.service';
 import path from "path";
 import fs from 'fs/promises';
 
 const router = express.Router();
 
 // Create a new record
+// TODO test route. Need a file as a buffer in request body
 router.post('/', async (req, res) => {
   /**
-   * Request needs to have
-   * 1. File as buffer
-   * 2. userId
-   * 3. questionId
+   * request.body needs to have
+   * 1. file: Buffer
+   * 2. userId: string | number
+   * 3. questionId: string | number
    */
   const FILE = req.body.file ? req.body.file : await fs.readFile(path.resolve(__dirname, 'testSample.jpg'));
   const USERID = req.body.userId ? req.body.userId : 1;
@@ -36,6 +43,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // Update a record by ID
+// TODO route tested, but maybe should update to a PATCH
 router.put('/:id', async (req, res) => {
   try {
     const record = await updateRecordingById(Number(req.params.id), req.body);
@@ -56,15 +64,18 @@ router.delete('/:id', async (req, res) => {
 });
 
 // Get all recordings for a single user
-// router.get('/', async (req, res) => {
-//   const {userId} = req.body;
-//   try {
-//     let userId: number;
-//     if (!userId) throw new Error('No user ID provided.');
-//
-//   } catch (e) {
-//     console.error(e.message);
-//   }
-// })
+router.get('/', async (req, res) => {
+  console.log(`GET ALL USERS RECORDINGS for user ${req.query.user}`);
+  const userId = Number(req.query.user);
+  try {
+    if (!userId) throw new Error('No user ID provided.');
+    console.log("After userId check");
+    const recordings = await getRecordingByUserId(userId);
+    res.status(200).json(recordings);
+  } catch (e) {
+    console.error(e.message);
+    res.status(500).json({ message: e.message });
+  }
+})
 
 export default router;

--- a/server/api/recording/recording.test.ts
+++ b/server/api/recording/recording.test.ts
@@ -1,9 +1,10 @@
-import { createRecording, getRecordingById, updateRecordingById, deleteRecordingById } from './recording.service';
+import { createRecording, getRecordingById, getRecordingByUserId, updateRecordingById, deleteRecordingById } from './recording.service';
 import fs from 'fs/promises';
 import path from "path";
 import {PrismaClient} from "@prisma/client";
 import fetch from 'node-fetch';
 import mime from 'mime-kind';
+import {checkFileExists} from "../../util/google-cloud/storage";
 
 async function downloadFileToBuffer(url: string) {
   const response = await fetch(url);
@@ -21,7 +22,7 @@ describe('Recording service unit tests', () => {
   }
   const filePath = path.resolve(__dirname, 'testSample.jpg');
 
-  it('should add a recording to database', async () => {
+  it('should upload a file and add a recording to database', async () => {
     // Read the file
     const buf = await fs.readFile(filePath);
     const {ext: extUpload} = await mime(buf);
@@ -35,6 +36,30 @@ describe('Recording service unit tests', () => {
 
     expect(url.includes("http")).toBeTruthy();
     expect(extDownload).toEqual(extUpload);
+
+    // Clean up
+  }, 10000)
+
+  it('should delete a recording from db and cloud storage', async () => {
+    const prisma = new PrismaClient();
+    // Upload
+    const buf = await fs.readFile(filePath);
+    const {id, objectKey} = await createRecording(buf, sampleRecording.userId, sampleRecording.questionId);
+
+    // Run deletion in database and GCS
+    await deleteRecordingById(id);
+
+    // Check test result
+    const fileExists = await checkFileExists(objectKey);
+    expect(fileExists).toBeFalsy();
+    const dbRow = await prisma.recording.findFirst({ where: {id} });
+    expect(dbRow).toBeFalsy();
+  })
+
+  it('should get all recording urls for a userId', async () => {
+    const recordings = await getRecordingByUserId(1);
+    expect(recordings.length).toBeGreaterThan(0);
+    expect(recordings[0].userId).toEqual(1);
   }, 10000)
 })
 


### PR DESCRIPTION
## How to call API route
- Getting recordings by user ID is implemented by query string `/recording/?user=userId`
- Returns an object with `url` key which contains a signed URL valid for 30 minutes